### PR TITLE
Add --without-sage flag for new command

### DIFF
--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -25,7 +25,7 @@ impl Bedrock {
       // If theme is set to Sage install Sage.
       match &self.theme {
         Theme::IsSage(theme) => theme.init(),
-        Theme::NotSage => panic!("Not Sage."),
+        Theme::NotSage => (),
       };
     } else {
       println!("Site {} already exists.", &self.name);

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -9,6 +9,9 @@ subcommands:
         - project:
             help: project name, e.g. example.com
             required: true
+        - without_sage:
+            help: Do not install Sage
+            long: without-sage
   - sage:
       about: Install and manage Sage
       subcommands:

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
   let m = App::from_yaml(cli).get_matches();
 
   if let Some(m) = m.subcommand_matches("new") {
-    new_project(m.value_of("project").unwrap());
+    new_project(m.value_of("project").unwrap(), m.is_present("without_sage"));
   };
 
   if let Some(m) = m.subcommand_matches("sage") {
@@ -18,8 +18,8 @@ fn main() {
   };
 }
 
-fn new_project(name: &str) {
+fn new_project(name: &str, without_sage: bool) {
   println!("Creating new Roots project...");
-  let project = Trellis::new(name.to_string());
+  let project = Trellis::new(name.to_string(), without_sage);
   project.init();
 }

--- a/src/trellis.rs
+++ b/src/trellis.rs
@@ -16,7 +16,9 @@ impl Trellis {
       name.to_string(),
       match without_sage {
         true => Theme::NotSage,
-        false => Theme::IsSage(Sage::new(String::from("sage"), &name.to_string())),
+        false => {
+          Theme::IsSage(Sage::new(String::from("sage"), &name.to_string()))
+        }
       },
     );
 

--- a/src/trellis.rs
+++ b/src/trellis.rs
@@ -11,10 +11,13 @@ pub struct Trellis {
 }
 
 impl Trellis {
-  pub fn new(name: String) -> Trellis {
+  pub fn new(name: String, without_sage: bool) -> Trellis {
     let site = Bedrock::new(
       name.to_string(),
-      Theme::IsSage(Sage::new(String::from("sage"), &name.to_string())),
+      match without_sage {
+        true => Theme::NotSage,
+        false => Theme::IsSage(Sage::new(String::from("sage"), &name.to_string())),
+      },
     );
 
     Trellis {


### PR DESCRIPTION
## Feature

Adds a conditional flag for the `new` project command which allows users to opt-out of installing Sage.

## Usage

```shell
$ roots new example.com --without-sage
```

Resolves #2 